### PR TITLE
Fixing Random Quote Bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@ sometimes, i just need a break</textarea>
         document.getElementById("randomTranslation").innerText = getRandomTranslation();
     }
     function randomQuote() {
-        document.getElementById("input").innerText = getRandomQuote();
+        document.getElementById("input").value = getRandomQuote();
         updateOutput();
     }
   </script>


### PR DESCRIPTION
There's a bug on generating Random Quote. 

Steps to reproduce: 
1. Open geeksay
2. Edit the layman input text
3. Click on Random Quote

It doesn't work.
I've changed the innerText to value for the textarea tag. Textarea elements don't have an innerHTML property.