### PR TITLE
Functionality to ignore symbols when translating words

### DIFF
--- a/geeksay.js
+++ b/geeksay.js
@@ -177,16 +177,16 @@ function geeksay(text) {
     return input.map(geeksayWord).join(' ');
 }
 
-function geeksayWord(text) {
-    if (isNumeric(text)) {
-        return (text >>> 0).toString(2);
+function geeksayWord(word) {
+    if (isNumeric(word)) {
+        return (word >>> 0).toString(2);
     }
     else {
-        lowerCaseText = removeSymbols(text).toLowerCase();
+        lowerCaseText = removeSymbols(word).toLowerCase();
         if (translations.hasOwnProperty(lowerCaseText)) {
-            text = text.toLowerCase().replace(lowerCaseText, translations[lowerCaseText]);
+            word = word.toLowerCase().replace(lowerCaseText, translations[lowerCaseText]);
         }
-        return text;
+        return word;
     }
 }
 

--- a/geeksay.js
+++ b/geeksay.js
@@ -149,7 +149,7 @@ function isNumeric(num){
 }
 
 function geeksay(text) {
-    const input =  Array.isArray(text) ? text : String(text).split(' ');
+    const input = Array.isArray(text) ? text : String(text).split(' ');
 
     return input.map(geeksayWord).join(' ');
 }
@@ -159,13 +159,18 @@ function geeksayWord(text) {
         return (text >>> 0).toString(2);
     }
     else {
-        lowerCaseText = text.toLowerCase();
+        lowerCaseText = removeSymbols(text).toLowerCase();
+
         if (translations.hasOwnProperty(lowerCaseText)) {
-            return translations[lowerCaseText];
+            return text.replace(lowerCaseText, translations[lowerCaseText]);
         } else {
             return text;
         }
     }
+}
+
+function removeSymbols(word) {
+    return word.replace(/[^a-zA-Z0-9]+/, '');
 }
 
 function getRandomTranslation() {

--- a/geeksay.js
+++ b/geeksay.js
@@ -150,7 +150,6 @@ function isNumeric(num){
 
 function geeksay(text) {
     const input = Array.isArray(text) ? text : String(text).split(' ');
-
     return input.map(geeksayWord).join(' ');
 }
 
@@ -160,12 +159,10 @@ function geeksayWord(text) {
     }
     else {
         lowerCaseText = removeSymbols(text).toLowerCase();
-
         if (translations.hasOwnProperty(lowerCaseText)) {
-            return text.replace(lowerCaseText, translations[lowerCaseText]);
-        } else {
-            return text;
+            text = text.replace(lowerCaseText, translations[lowerCaseText]);
         }
+        return text;
     }
 }
 

--- a/geeksay.js
+++ b/geeksay.js
@@ -184,7 +184,7 @@ function geeksayWord(text) {
     else {
         lowerCaseText = removeSymbols(text).toLowerCase();
         if (translations.hasOwnProperty(lowerCaseText)) {
-            text = text.replace(text, translations[lowerCaseText]);
+            text = text.toLowerCase().replace(lowerCaseText, translations[lowerCaseText]);
         }
         return text;
     }

--- a/geeksay.js
+++ b/geeksay.js
@@ -184,14 +184,14 @@ function geeksayWord(text) {
     else {
         lowerCaseText = removeSymbols(text).toLowerCase();
         if (translations.hasOwnProperty(lowerCaseText)) {
-            text = text.replace(lowerCaseText, translations[lowerCaseText]);
+            text = text.replace(text, translations[lowerCaseText]);
         }
         return text;
     }
 }
 
 function removeSymbols(word) {
-    return word.replace(/[^a-zA-Z0-9]+/, '');
+    return word.replace(/(?!\n|\r\n)[^a-zA-Z0-9]+/, '');
 }
 
 function getRandomTranslation() {

--- a/test/geeksay.test.js
+++ b/test/geeksay.test.js
@@ -57,10 +57,13 @@ describe('multi-line and symbols', () => {
     should.equal(geeksay('(=> I love my house )'), '(=> I <3 my 127.0.0.1 )');
   });
 
-  // TODO:
-  // it('symbols #3', () => {
-  // 	should.equal(geeksay('I love my house!'), 'I <3 my 127.0.0.1!');
-  // });
+  it('symbols #3', () => {
+  	should.equal(geeksay('I love my house!'), 'I <3 my 127.0.0.1!');
+  });
+  
+  it('symbols #4', () => {
+  	should.equal(geeksay('Roses are red, violets are blue.'), 'Roses are #ff0000, violets are #0000ff.');
+  });
 
 });
 


### PR DESCRIPTION
#63 Created a regex to parse the word and remove symbols.

>Roses are red, violets are blue.
>Roses are #ff0000, violets are #0000ff.
