### PR TITLE
Remove duplicate vocab entry for 'plus: +'

### DIFF
--- a/geeksay.js
+++ b/geeksay.js
@@ -98,7 +98,6 @@ const translations = {
     "equal": "=",
     "remove": "rm",
     "move": "mv",
-    "plus": "+",
     "random": "rand",
     "mathematics": "math",
     "heart": "<3",


### PR DESCRIPTION
I noticed a vocab appeared twice in the list: `"plus": "+"`.
This PR removes the duplicate entry.