### PR TITLE
Fix broken numeric check

### DIFF
--- a/geeksay.js
+++ b/geeksay.js
@@ -169,7 +169,7 @@ const quotes = [
 ]
 
 function isNumeric(num) {
-    return !isNaN(parseInt(num));
+    return !isNaN(num);
 }
 
 function geeksay(text) {


### PR DESCRIPTION
The current implementation of `isNumeric` (`!isNaN(parseInt(num))`) causes false positives due to how `parseInt` tries to cast non-numbers. For example:

```javascript
!isNaN(parseInt("123ABC")) === true
geeksay("123a") === "0"
```

See [this reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN) for more details. This fix uses `!isNaN(num)` instead, which will produce more consistent results by not relying on `parseInt`.