### PR TITLE
Improve number handling

### DIFF
--- a/geeksay.js
+++ b/geeksay.js
@@ -180,7 +180,7 @@ function geeksay(text) {
 
 function geeksayWord(text) {
     if (isNumeric(text)) {
-        return (text >>> 0).toString(2);
+        return Math.trunc(text).toString(2);
     }
     else {
         lowerCaseText = text.toLowerCase();

--- a/geeksay.js
+++ b/geeksay.js
@@ -169,7 +169,7 @@ const quotes = [
 ]
 
 function isNumeric(num) {
-    return !isNaN(parseInt(num));
+    return /^-?\d+(\.\d+)?$/.test(num);
 }
 
 function geeksay(text) {

--- a/test/geeksay.test.js
+++ b/test/geeksay.test.js
@@ -93,6 +93,6 @@ describe('inputs', () => {
   });
 
   it('array of numbers', () => {
-    should.equal(geeksay([1, 2, 3, 4, '100']), '1 10 11 100 1100100');
+    should.equal(geeksay([1, 2, 3, 4, '100', '-20']), '1 10 11 100 1100100 -10100');
   });
 });


### PR DESCRIPTION
The current implementation of `isNumeric` (`!isNaN(parseInt(num))`) causes false positives due to how `parseInt` tries to cast non-numbers. For example:

```javascript
!isNaN(parseInt("123ABC")) === true
geeksay("123a") === "0"
```

Removing the `parseInt` call and using just `!isNaN(num)` is also ineffective due to cast errors such as `" "` becoming `0`. See [this reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN) for more details. This fix uses a regex instead, which will produce more consistent results by not relying on `parseInt`. It won't catch special number formats that would otherwise be caught (such as `0x123` or `1.23e2`), but these are probably less important than accidentally converting non-numeric words.

The truncation to convert floats to ints for binary translation has also been fixed to use `Math.trunc` instead of a binary right-shift, which fails on negative numbers. An appropriate test has been added.