### PR TITLE
Test for duplicates on current code structure (issue #209)

### DIFF
--- a/geeksay.js
+++ b/geeksay.js
@@ -120,7 +120,6 @@ const translations = {
     "death": "BSOD",
     "wait": "load",
     "waiting": "loading",
-    "forbidden": "403",
     "unauthorized": "401",
     "nothing": "void",
 }


### PR DESCRIPTION
Solves #209 for the current code by parsing the library code and checking for duplicate key entries.

- The test uses the esprima library ([esprima.org](https://esprima.org/)) for parsing the JavaScript library, locates the `translations` variable and extracts the translation key entries. 
- The test does not require any changes of framework (esprima is already included as a devDependency through mocha).
- The test did find an existing duplicate entry, "forbidden" -> "403", which I removed.
- The test only works as long as the translation dictionary will keep its current form of a single assignment to the global variable.
- The test fails if duplicate entries are found and errors when the geeksay.js file could not be opened or the translations variable was not found (although the filename and variable name can of course be easily changed in the test if necessary).