### PR TITLE
Very minor change to fix issue #310

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,7 @@
     border-radius: 3px;
     font-weight: 500;
     font-family: monospace;
+	overflow-wrap: break-word;
   }
   .twitter-tweet-button {
     float: right;


### PR DESCRIPTION
[#310](https://github.com/swapagarwal/geeksay/issues/310) Was about long words not being completely visible in the output box. I just added overflow-wrap: break-word; to the CSS properties of #output so that it mimics the input box.