### PR TITLE
Error Fixed!

### DIFF
--- a/geeksay.js
+++ b/geeksay.js
@@ -125,7 +125,7 @@ const translations = {
     "waiting": "loading",
     "unauthorized": "401",
     "nothing": "void",
-    "style": "CSS"
+    "style": "CSS",
     "developer": "dev"
 }
 


### PR DESCRIPTION
Syntax error caused translator to break which is apparently now fixed by adding a single ','.