### PR TITLE
Updating KILL to alt+f4 from ctrl+c  (Hacktoberfest)

### DIFF
--- a/geeksay.js
+++ b/geeksay.js
@@ -48,7 +48,7 @@ const translations = {
   address: "url",
   pie: "π",
   function: "fn",
-  kill: "ctrl+c",
+  kill: "alt+f4",
   stop: "abort",
   refresh: "f5",
   slow: "O(n^n)",


### PR DESCRIPTION
Update the kill translation to alt+f4 from ctrl+c ( which is **copy**)
alt+f4 used to close any application in windows