### PR TITLE
Updated #output styling to support firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,8 @@
 
   #output {
     display: inline-block;    
-    width: -webkit-fill-available;
+    width: 100%;
+    box-sizing: border-box;
     padding: 15px;
     background-color: #151718;
     color: #2196f3;


### PR DESCRIPTION
-webkit-fill-available is an invalid property value in Firefox. The layout is now consistent in all browsers. I've edited the width value and sat the box-sizing property to border-box so it can have the same layout as before.

Currently in Firefox it looks like this
![image](https://user-images.githubusercontent.com/115582821/195927358-14e8fd7c-e55d-4d19-9400-1bc6df74ed71.png)

My edited version looks like this
![image](https://user-images.githubusercontent.com/115582821/195928531-ad3d0259-2c0c-4b67-8218-c64dfe8167aa.png)
