### PR TITLE
Add new translations and corresponding quotes

### DIFF
--- a/geeksay.js
+++ b/geeksay.js
@@ -179,6 +179,8 @@ const translations = {
   leave: "alt+f4",
   mistake: "ERROR",
   divide: "/",
+  confidence: "ssl_certificate",
+  journey: "algorithm",
 };
 
 const translationsMap = new Map(Object.entries(translations));
@@ -272,6 +274,8 @@ const quotes = [
   "Don't leave blank space in your code!", // Don't alt+f4 blank ' ' in your code!
   "Sometimes it's okay to run", // Sometimes it's okay to ctrl+F5
   "Divide and conquer", // / and conquer
+  "Confidence is key", // ssl_certificate is key
+  "Life is a journey", // Life is an algorithm
 ];
 
 function isNumeric(num) {


### PR DESCRIPTION
In this Pull Request, I've added new translations to the 'translations' object and corresponding phrases to the 'quotes' list. The additions include:

1. 'journey' translated to 'algorithm'
2. 'Life is a journey' becomes 'Life is an algorithm'
3. 'confidence' translated to 'ssl_certificate'
4. 'Confidence is key' becomes 'SSL Certificate is key'
