### PR TITLE
Download image functionality added

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,8 +450,13 @@ sometimes, i just need a break</textarea>
         </button>
         <button class="tweet-btn random-quote-button fb-btn share-popup" onclick="postFacebook()">
           <i class="fa-brands fa-facebook-f"></i>
-          &emsp;Share
+          &emsp;Facebook
         </button>
+        <button class="tweet-btn random-quote-button fb-btn share-popup" onclick="downloadImage()">
+            Download Image
+        </button>
+          <canvas id="canvas" style="display:none;"></canvas>
+
       </div>
     </div>
     <div id="footer">
@@ -554,6 +559,64 @@ sometimes, i just need a break</textarea>
       const url = 'https://www.facebook.com/sharer/sharer.php?u=https://www.geeksay.xyz';
       window.open(url);
     }
+
+    function wrapText(context, text, x, y, maxWidth, lineHeight) {
+        const lines = text.split('\n');
+        let totalHeight = lines.length * lineHeight;
+
+        y -= totalHeight / 2;
+
+        for (let i = 0; i < lines.length; i++) {
+            const words = lines[i].split(' ');
+            let line = '';
+
+            for (let n = 0; n < words.length; n++) {
+                let testLine = line + words[n] + ' ';
+                let metrics = context.measureText(testLine);
+                let testWidth = metrics.width;
+                if (testWidth > maxWidth && n > 0) {
+                    context.fillText(line, x, y);
+                    line = words[n] + ' ';
+                    y += lineHeight;
+                } else {
+                    line = testLine;
+                }
+            }
+            context.fillText(line, x, y);
+            y += lineHeight;
+        }
+    }
+
+    function downloadImage() {
+        const unformattedText = document.getElementById('output').innerText + '\n #geeksay';
+
+        let canvas = document.getElementById('canvas');
+        let ctx = canvas.getContext('2d');
+
+        canvas.width = 1080;
+        canvas.height = 1920;
+
+        ctx.fillStyle = '#000';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        ctx.font = '48px Ubuntu';
+        ctx.fillStyle = '#FFFFFF';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'middle';
+
+        wrapText(ctx, unformattedText, 150, canvas.height / 2, canvas.width - 300, 80);
+
+        let imageURL = canvas.toDataURL('image/png');
+
+        // Trigger download
+        let downloadLink = document.createElement('a');
+        downloadLink.href = imageURL;
+        downloadLink.download = 'quote.png';
+        document.body.appendChild(downloadLink);
+        downloadLink.click();
+        document.body.removeChild(downloadLink);
+    }
+
     function getActualOutput() {
       var value = "";
       var nodes = output.children;


### PR DESCRIPTION
I added a "Download Image" button next to the Twitter and Facebook sharing buttons (screenshots and example image attached). It triggers the downloadImage() function where the transformed quote will be inserted into an image along with the #geeksay hashtag, and the image will then be automatically downloaded. I set the dimensions of the image to fit the phone screen and suitable for sharing on Instagram stories. Please let me know if there's anything that needs to be improved. Thank you!


![quote](https://github.com/swapagarwal/geeksay/assets/99091618/c7f41d76-4c8e-4dd8-b219-2c67d59be5fc)
<img width="1433" alt="Screenshot" src="https://github.com/swapagarwal/geeksay/assets/99091618/793bf57a-c769-4002-a412-019e77ee9b67">
